### PR TITLE
Exclude Building for Windows on Arm64 on Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         goos: [darwin, linux, windows]
         goarch: [amd64, arm64]
+        exclude:
+          - goos: windows
+            goarch: arm64
     steps:
       - uses: actions/checkout@v2
       - uses: wangyoucao577/go-release-action@v1.14


### PR DESCRIPTION
Windows and Arm64 do not mix yet for Go.  Removing that combination when a release is created.